### PR TITLE
Add initial support for GQ signatures

### DIFF
--- a/gq/gq.go
+++ b/gq/gq.go
@@ -41,20 +41,17 @@ type signerVerifier struct {
 	vBytes int
 	// t is the signature length parameter
 	t int
-
-	rng io.Reader
 }
 
 // NewSignerVerifier creates a SignerVerifier from the RSA public key of the trusted third-party which creates
 // the GQ1 private numbers.
 //
 // The securityParameter parameter is the level of desired security in bits. 256 is recommended.
-// The rng parameter should probably be set to [crypto/rand.Reader].
-func NewSignerVerifier(publicKey *rsa.PublicKey, securityParameter int, rng io.Reader) SignerVerifier {
+func NewSignerVerifier(publicKey *rsa.PublicKey, securityParameter int) SignerVerifier {
 	n, v, nBytes, vBytes := parsePublicKey(publicKey)
 	t := securityParameter / (vBytes * 8)
 
-	return &signerVerifier{n, v, nBytes, vBytes, t, rng}
+	return &signerVerifier{n, v, nBytes, vBytes, t}
 }
 
 func parsePublicKey(publicKey *rsa.PublicKey) (n *big.Int, v *big.Int, nBytes int, vBytes int) {

--- a/gq/gq.go
+++ b/gq/gq.go
@@ -1,0 +1,73 @@
+package gq
+
+import (
+	"crypto/rsa"
+	"io"
+	"math/big"
+
+	"golang.org/x/crypto/sha3"
+)
+
+type Prover interface {
+	Prove(identity []byte, signature []byte) []byte
+	ProveJWTSignature(jwt []byte) ([]byte, error)
+}
+
+type Verifier interface {
+	Verify(proof []byte, identity []byte) bool
+}
+
+type ProverVerifier interface {
+	Prover
+	Verifier
+}
+
+type proverVerifier struct {
+	n      *big.Int
+	v      *big.Int
+	nBytes int
+	vBytes int
+	t      int
+
+	rng io.Reader
+}
+
+func NewProverVerifier(publicKey *rsa.PublicKey, securityParameter int, rng io.Reader) ProverVerifier {
+	n, v, nBytes, vBytes := parsePublicKey(publicKey)
+	t := securityParameter / (vBytes * 8)
+
+	return &proverVerifier{n, v, nBytes, vBytes, t, rng}
+}
+
+func parsePublicKey(publicKey *rsa.PublicKey) (n *big.Int, v *big.Int, nBytes int, vBytes int) {
+	n, v = publicKey.N, big.NewInt(int64(publicKey.E))
+	nLen := n.BitLen()
+	vLen := v.BitLen() - 1
+	nBytes = bytesForBits(nLen)
+	vBytes = bytesForBits(vLen)
+	return
+}
+
+func bytesForBits(bits int) int {
+	return (bits + 7) / 8
+}
+
+func hash(byteCount int, data ...[]byte) []byte {
+	rng := sha3.NewShake256()
+	for _, d := range data {
+		rng.Write(d)
+	}
+
+	return randomBytes(rng, byteCount)
+}
+
+func randomBytes(rng io.Reader, byteCount int) []byte {
+	bytes := make([]byte, byteCount)
+
+	_, err := io.ReadFull(rng, bytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return bytes
+}

--- a/gq/gq.go
+++ b/gq/gq.go
@@ -8,21 +8,21 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-type Prover interface {
-	Prove(identity []byte, signature []byte) []byte
-	ProveJWTSignature(jwt []byte) ([]byte, error)
+type Signer interface {
+	Sign(private []byte, message []byte) []byte
+	SignJWTIdentity(jwt []byte) ([]byte, error)
 }
 
 type Verifier interface {
 	Verify(proof []byte, identity []byte) bool
 }
 
-type ProverVerifier interface {
-	Prover
+type SignerVerifier interface {
+	Signer
 	Verifier
 }
 
-type proverVerifier struct {
+type signerVerifier struct {
 	n      *big.Int
 	v      *big.Int
 	nBytes int
@@ -32,11 +32,11 @@ type proverVerifier struct {
 	rng io.Reader
 }
 
-func NewProverVerifier(publicKey *rsa.PublicKey, securityParameter int, rng io.Reader) ProverVerifier {
+func NewSignerVerifier(publicKey *rsa.PublicKey, securityParameter int, rng io.Reader) SignerVerifier {
 	n, v, nBytes, vBytes := parsePublicKey(publicKey)
 	t := securityParameter / (vBytes * 8)
 
-	return &proverVerifier{n, v, nBytes, vBytes, t, rng}
+	return &signerVerifier{n, v, nBytes, vBytes, t, rng}
 }
 
 func parsePublicKey(publicKey *rsa.PublicKey) (n *big.Int, v *big.Int, nBytes int, vBytes int) {

--- a/gq/gq.go
+++ b/gq/gq.go
@@ -8,30 +8,48 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// Signer allows for creating GQ1 signatures messages.
 type Signer interface {
+	// Sign creates a GQ1 signature over the given message with the given GQ1 private number.
 	Sign(private []byte, message []byte) []byte
+	// SignJWTIdentity creates a GQ1 signature over the JWT token's header/payload with a GQ1 private number derived from the JWT signature.
+	//
+	// This works because a GQ1 private number can be calculated as the inverse mod n of an RSA signature, where n is the public RSA modulus.
 	SignJWTIdentity(jwt []byte) ([]byte, error)
 }
 
+// Signer allows for verifying GQ1 signatures.
 type Verifier interface {
-	Verify(proof []byte, identity []byte) bool
+	// Verify verifies a GQ1 signature over a message, using the public identity of the signer.
+	Verify(signature []byte, identity []byte, message []byte) bool
 }
 
+// SignerVerifier combines the Signer and Verifier interfaces.
 type SignerVerifier interface {
 	Signer
 	Verifier
 }
 
 type signerVerifier struct {
-	n      *big.Int
-	v      *big.Int
+	// n is the RSA public modulus (what Go's RSA lib calls N)
+	n *big.Int
+	// v is the RSA public exponent (what Go's RSA lib calls E)
+	v *big.Int
+	// nBytes is the length of n in bytes
 	nBytes int
+	// vBytes is the length of v in bytes
 	vBytes int
-	t      int
+	// t is the signature length parameter
+	t int
 
 	rng io.Reader
 }
 
+// NewSignerVerifier creates a SignerVerifier from the RSA public key of the trusted third-party which creates
+// the GQ1 private numbers.
+//
+// The securityParameter parameter is the level of desired security in bits. 256 is recommended.
+// The rng parameter should probably be set to [crypto/rand.Reader].
 func NewSignerVerifier(publicKey *rsa.PublicKey, securityParameter int, rng io.Reader) SignerVerifier {
 	n, v, nBytes, vBytes := parsePublicKey(publicKey)
 	t := securityParameter / (vBytes * 8)
@@ -42,7 +60,7 @@ func NewSignerVerifier(publicKey *rsa.PublicKey, securityParameter int, rng io.R
 func parsePublicKey(publicKey *rsa.PublicKey) (n *big.Int, v *big.Int, nBytes int, vBytes int) {
 	n, v = publicKey.N, big.NewInt(int64(publicKey.E))
 	nLen := n.BitLen()
-	vLen := v.BitLen() - 1
+	vLen := v.BitLen() - 1 // note the -1; GQ1 only ever uses the (length of v) - 1, so we can just do this here rather than throughout
 	nBytes = bytesForBits(nLen)
 	vBytes = bytesForBits(vLen)
 	return

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -40,9 +39,7 @@ func TestProveVerify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fmt.Printf("gqSig: %s\n", gqSig)
-
-	ok := signerVerifier.Verify(gqSig, identity)
+	ok := signerVerifier.Verify(gqSig, identity, identity)
 	if !ok {
 		t.Fatal("couldn't verify signature we just made")
 	}

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -29,19 +29,22 @@ func TestProveVerify(t *testing.T) {
 
 	idToken := createOIDCToken(insecureRNG, oidcPrivKey, "test")
 
-	signingPayload, signature, err := util.SplitDecodeJWTSignature(idToken)
+	identity, _, err := util.SplitDecodeJWTSignature(idToken)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	proverVerifier := gq.NewProverVerifier(oidcPubKey, 256, insecureRNG)
-	gqProof := proverVerifier.Prove(signingPayload, signature)
+	signerVerifier := gq.NewSignerVerifier(oidcPubKey, 256, insecureRNG)
+	gqSig, err := signerVerifier.SignJWTIdentity(idToken)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	fmt.Printf("gqProof: %s\n", gqProof)
+	fmt.Printf("gqSig: %s\n", gqSig)
 
-	ok := proverVerifier.Verify(gqProof, signingPayload)
+	ok := signerVerifier.Verify(gqSig, identity)
 	if !ok {
-		t.Fatal("couldn't verify proof we just made")
+		t.Fatal("couldn't verify signature we just made")
 	}
 }
 

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -1,0 +1,86 @@
+package gq_test
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	insecurerand "math/rand"
+
+	"github.com/bastionzero/openpubkey/gq"
+	"github.com/bastionzero/openpubkey/util"
+)
+
+func TestProveVerify(t *testing.T) {
+	insecureRNG := insecurerand.New(insecurerand.NewSource(1))
+
+	oidcPrivKey, err := rsa.GenerateKey(insecureRNG, 2048)
+	if err != nil {
+		panic(err)
+	}
+
+	oidcPubKey := &oidcPrivKey.PublicKey
+
+	idToken := createOIDCToken(insecureRNG, oidcPrivKey, "test")
+
+	signingPayload, signature, err := util.SplitDecodeJWTSignature(idToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proverVerifier := gq.NewProverVerifier(oidcPubKey, 256, insecureRNG)
+	gqProof := proverVerifier.Prove(signingPayload, signature)
+
+	fmt.Printf("gqProof: %s\n", gqProof)
+
+	ok := proverVerifier.Verify(gqProof, signingPayload)
+	if !ok {
+		t.Fatal("couldn't verify proof we just made")
+	}
+}
+
+func createOIDCToken(rng io.Reader, oidcPrivKey *rsa.PrivateKey, audience string) []byte {
+	oidcHeader := map[string]any{
+		"alg": "RS256",
+		"typ": "JWT",
+	}
+	oidcPayload := map[string]any{
+		"sub": "1",
+		"iss": "test",
+		"aud": audience,
+		"iat": time.Now().Unix(),
+	}
+
+	oidcHeaderJSON, err := json.Marshal(oidcHeader)
+	if err != nil {
+		panic(err)
+	}
+	oidcPayloadJSON, err := json.Marshal(oidcPayload)
+	if err != nil {
+		panic(err)
+	}
+
+	var buf bytes.Buffer
+	buf.Write(util.Base64EncodeForJWT(oidcHeaderJSON))
+	buf.WriteByte('.')
+	buf.Write(util.Base64EncodeForJWT(oidcPayloadJSON))
+	oidcSigningPayload := buf.Bytes()
+
+	hash := sha256.Sum256(oidcSigningPayload)
+	oidcSigRaw, err := rsa.SignPKCS1v15(rng, oidcPrivKey, crypto.SHA256, hash[:])
+	if err != nil {
+		panic(err)
+	}
+
+	oidcSig := util.Base64EncodeForJWT(oidcSigRaw)
+	buf.WriteByte('.')
+	buf.Write(oidcSig)
+
+	return buf.Bytes()
+}

--- a/gq/prove.go
+++ b/gq/prove.go
@@ -1,0 +1,75 @@
+package gq
+
+import (
+	"crypto/rand"
+	"math/big"
+
+	"github.com/bastionzero/openpubkey/util"
+)
+
+func (pv *proverVerifier) Prove(signingPayload []byte, signature []byte) []byte {
+	n, v, t := pv.n, pv.v, pv.t
+	nBytes, vBytes := pv.nBytes, pv.vBytes
+
+	x := new(big.Int).SetBytes(signature)
+	Q := new(big.Int).ModInverse(x, n)
+
+	M := signingPayload
+
+	r := randomNumbers(t, nBytes)
+
+	var W []byte
+	for i := 0; i < t; i++ {
+		W_i := new(big.Int).Exp(r[i], v, n)
+		b := make([]byte, nBytes)
+		W = append(W, W_i.FillBytes(b)...)
+	}
+
+	R := hash(t*vBytes, W, M)
+
+	Rs := make([]*big.Int, t)
+	for i := 0; i < t; i++ {
+		Rs[i] = new(big.Int).SetBytes(R[i*vBytes : (i+1)*vBytes])
+	}
+
+	var S []byte
+	for i := 0; i < t; i++ {
+		S_i := new(big.Int).Exp(Q, Rs[i], n)
+		S_i.Mul(S_i, r[i])
+		S_i.Mod(S_i, n)
+		b := make([]byte, nBytes)
+		S = append(S, S_i.FillBytes(b)...)
+	}
+
+	return encodeProof(R, S)
+}
+
+func (pv *proverVerifier) ProveJWTSignature(jwt []byte) ([]byte, error) {
+	signingPayload, signature, err := util.SplitDecodeJWTSignature(jwt)
+	if err != nil {
+		return nil, err
+	}
+
+	proof := pv.Prove(signingPayload, signature)
+	return proof, nil
+}
+
+func encodeProof(R, S []byte) []byte {
+	var bin []byte
+
+	bin = append(bin, R...)
+	bin = append(bin, S...)
+
+	return util.Base64Encode(bin)
+}
+
+func randomNumbers(t int, nBytes int) []*big.Int {
+	ys := make([]*big.Int, t)
+
+	for i := 0; i < t; i++ {
+		bytes := randomBytes(rand.Reader, nBytes)
+		ys[i] = new(big.Int).SetBytes(bytes)
+	}
+
+	return ys
+}

--- a/gq/rsa.go
+++ b/gq/rsa.go
@@ -8,7 +8,8 @@ import (
 // Hardcoded padding prefix for SHA-256 from https://github.com/golang/go/blob/eca5a97340e6b475268a522012f30e8e25bb8b8f/src/crypto/rsa/pkcs1v15.go#L268
 var prefix = []byte{0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20}
 
-// encodePKCS1v15 is taken from the go stdlib, see rsa.SignPKCS1v15.
+// encodePKCS1v15 is taken from the go stdlib, see [crypto/rsa.SignPKCS1v15].
+//
 // https://github.com/golang/go/blob/eca5a97340e6b475268a522012f30e8e25bb8b8f/src/crypto/rsa/pkcs1v15.go#L287-L317
 func encodePKCS1v15(k int, data []byte) []byte {
 	hashLen := crypto.SHA256.Size()

--- a/gq/rsa.go
+++ b/gq/rsa.go
@@ -1,0 +1,28 @@
+package gq
+
+import (
+	"crypto"
+	"crypto/sha256"
+)
+
+// Hardcoded padding prefix for SHA-256 from https://github.com/golang/go/blob/eca5a97340e6b475268a522012f30e8e25bb8b8f/src/crypto/rsa/pkcs1v15.go#L268
+var prefix = []byte{0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20}
+
+// encodePKCS1v15 is taken from the go stdlib, see rsa.SignPKCS1v15.
+// https://github.com/golang/go/blob/eca5a97340e6b475268a522012f30e8e25bb8b8f/src/crypto/rsa/pkcs1v15.go#L287-L317
+func encodePKCS1v15(k int, data []byte) []byte {
+	hashLen := crypto.SHA256.Size()
+	tLen := len(prefix) + hashLen
+
+	// EM = 0x00 || 0x01 || PS || 0x00 || T
+	em := make([]byte, k)
+	em[1] = 1
+	for i := 2; i < k-tLen-1; i++ {
+		em[i] = 0xff
+	}
+	copy(em[k-tLen:k-hashLen], prefix)
+
+	hashed := sha256.Sum256(data)
+	copy(em[k-hashLen:k], hashed[:])
+	return em
+}

--- a/gq/verify.go
+++ b/gq/verify.go
@@ -1,0 +1,71 @@
+package gq
+
+import (
+	"fmt"
+	"math/big"
+	"slices"
+
+	"github.com/bastionzero/openpubkey/util"
+)
+
+func (pv *proverVerifier) Verify(proof []byte, signingPayload []byte) bool {
+	n, v, t := pv.n, pv.v, pv.t
+	nBytes, vBytes := pv.nBytes, pv.vBytes
+
+	paddedPayload := encodePKCS1v15(nBytes, signingPayload)
+	G := new(big.Int).SetBytes(paddedPayload)
+
+	R, S, err := pv.decodeProof(proof)
+	if err != nil {
+		return false
+	}
+
+	M := signingPayload
+
+	Rs := make([]*big.Int, t)
+	for i := 0; i < t; i++ {
+		Rs[i] = new(big.Int).SetBytes(R[i*vBytes : (i+1)*vBytes])
+	}
+
+	Ss := make([]*big.Int, t)
+	for i := 0; i < t; i++ {
+		s_i := new(big.Int).SetBytes(S[i*nBytes : (i+1)*nBytes])
+		if s_i.Cmp(big.NewInt(0)) == 0 || s_i.Cmp(n) != -1 {
+			return false
+		}
+		Ss[i] = s_i
+	}
+
+	var W []byte
+	for i := 0; i < t; i++ {
+		l := new(big.Int).Exp(Ss[i], v, n)
+		r := new(big.Int).Exp(G, Rs[i], n)
+		W_i := new(big.Int).Mul(l, r)
+		W_i.Mod(W_i, n)
+		b := make([]byte, nBytes)
+		W = append(W, W_i.FillBytes(b)...)
+	}
+
+	Rstar := hash(t*vBytes, W, M)
+
+	return slices.Equal(R, Rstar)
+}
+
+func (pv *proverVerifier) decodeProof(s []byte) (R, S []byte, err error) {
+	bin, err := util.Base64Decode(s)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rSize := pv.vBytes * pv.t
+	sSize := pv.nBytes * pv.t
+
+	if len(bin) != rSize+sSize {
+		return nil, nil, fmt.Errorf("not the correct size")
+	}
+
+	R = bin[:rSize]
+	S = bin[rSize:]
+
+	return R, S, nil
+}

--- a/gq/verify.go
+++ b/gq/verify.go
@@ -8,46 +8,63 @@ import (
 	"github.com/bastionzero/openpubkey/util"
 )
 
-func (sv *signerVerifier) Verify(proof []byte, signingPayload []byte) bool {
+// Verify verifies a GQ1 signature over a message, using the public identity of the signer.
+//
+// Comments throughout refer to stages as specified in the ISO/IEC 14888-2 standard.
+func (sv *signerVerifier) Verify(proof []byte, identity []byte, message []byte) bool {
 	n, v, t := sv.n, sv.v, sv.t
 	nBytes, vBytes := sv.nBytes, sv.vBytes
 
-	paddedPayload := encodePKCS1v15(nBytes, signingPayload)
-	G := new(big.Int).SetBytes(paddedPayload)
+	M := message
 
+	// Stage 0 - reject proof if it's the wrong size based on t
 	R, S, err := sv.decodeProof(proof)
 	if err != nil {
 		return false
 	}
 
-	M := signingPayload
+	// Stage 1 - create public number G
+	// currently this hardcoded to use PKCS#1 v1.5 padding as the format mechanism
+	paddedIdentity := encodePKCS1v15(nBytes, identity)
+	G := new(big.Int).SetBytes(paddedIdentity)
 
+	// Stage 2 - parse signature numbers and recalculate test number W*
+	// split R into t strings, each consisting of vBytes bytes
 	Rs := make([]*big.Int, t)
 	for i := 0; i < t; i++ {
 		Rs[i] = new(big.Int).SetBytes(R[i*vBytes : (i+1)*vBytes])
 	}
 
+	// split S into t strings, each consisting of nBytes bytes
 	Ss := make([]*big.Int, t)
 	for i := 0; i < t; i++ {
 		s_i := new(big.Int).SetBytes(S[i*nBytes : (i+1)*nBytes])
+		// reject if S_i = 0 or >= n
 		if s_i.Cmp(big.NewInt(0)) == 0 || s_i.Cmp(n) != -1 {
 			return false
 		}
 		Ss[i] = s_i
 	}
 
-	var W []byte
+	// recalculate test number W*
+	// for i from 1 to t, compute W*_i <- S_i^v * G^{R_i} mod n
+	// combine to form W*
+
+	var Wstar []byte
 	for i := 0; i < t; i++ {
 		l := new(big.Int).Exp(Ss[i], v, n)
 		r := new(big.Int).Exp(G, Rs[i], n)
-		W_i := new(big.Int).Mul(l, r)
-		W_i.Mod(W_i, n)
+		Wstar_i := new(big.Int).Mul(l, r)
+		Wstar_i.Mod(Wstar_i, n)
 		b := make([]byte, nBytes)
-		W = append(W, W_i.FillBytes(b)...)
+		Wstar = append(Wstar, Wstar_i.FillBytes(b)...)
 	}
 
-	Rstar := hash(t*vBytes, W, M)
+	// Stage 3 - recalculate question number R*
+	// hash W* and M and take first t*vBytes bytes as R*
+	Rstar := hash(t*vBytes, Wstar, M)
 
+	// Stage 4 - accept or reject depending on whether R and R* are identical
 	return slices.Equal(R, Rstar)
 }
 

--- a/gq/verify.go
+++ b/gq/verify.go
@@ -8,14 +8,14 @@ import (
 	"github.com/bastionzero/openpubkey/util"
 )
 
-func (pv *proverVerifier) Verify(proof []byte, signingPayload []byte) bool {
-	n, v, t := pv.n, pv.v, pv.t
-	nBytes, vBytes := pv.nBytes, pv.vBytes
+func (sv *signerVerifier) Verify(proof []byte, signingPayload []byte) bool {
+	n, v, t := sv.n, sv.v, sv.t
+	nBytes, vBytes := sv.nBytes, sv.vBytes
 
 	paddedPayload := encodePKCS1v15(nBytes, signingPayload)
 	G := new(big.Int).SetBytes(paddedPayload)
 
-	R, S, err := pv.decodeProof(proof)
+	R, S, err := sv.decodeProof(proof)
 	if err != nil {
 		return false
 	}
@@ -51,14 +51,14 @@ func (pv *proverVerifier) Verify(proof []byte, signingPayload []byte) bool {
 	return slices.Equal(R, Rstar)
 }
 
-func (pv *proverVerifier) decodeProof(s []byte) (R, S []byte, err error) {
+func (sv *signerVerifier) decodeProof(s []byte) (R, S []byte, err error) {
 	bin, err := util.Base64Decode(s)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	rSize := pv.vBytes * pv.t
-	sSize := pv.nBytes * pv.t
+	rSize := sv.vBytes * sv.t
+	sSize := sv.nBytes * sv.t
 
 	if len(bin) != rSize+sSize {
 		return nil, nil, fmt.Errorf("not the correct size")

--- a/util/base64.go
+++ b/util/base64.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"encoding/base64"
+)
+
+func Base64Encode(decoded []byte) []byte {
+	return base64Encode(decoded, base64.StdEncoding)
+}
+
+func Base64Decode(encoded []byte) ([]byte, error) {
+	return base64Decode(encoded, base64.StdEncoding)
+}
+
+func Base64EncodeForJWT(decoded []byte) []byte {
+	return base64Encode(decoded, base64.RawURLEncoding)
+}
+
+func Base64DecodeForJWT(encoded []byte) ([]byte, error) {
+	return base64Decode(encoded, base64.RawURLEncoding)
+}
+
+func base64Encode(decoded []byte, encoding *base64.Encoding) []byte {
+	encoded := make([]byte, encoding.EncodedLen(len(decoded)))
+	encoding.Encode(encoded, decoded)
+	return encoded
+}
+
+func base64Decode(encoded []byte, encoding *base64.Encoding) ([]byte, error) {
+	decoded := make([]byte, encoding.DecodedLen(len(encoded)))
+	n, err := encoding.Decode(decoded, encoded)
+	if err != nil {
+		return nil, err
+	}
+	return decoded[:n], nil
+}

--- a/util/jwt.go
+++ b/util/jwt.go
@@ -1,0 +1,29 @@
+package util
+
+import "fmt"
+
+func SplitDecodeJWTSignature(jwt []byte) (signingPayload []byte, signature []byte, err error) {
+	foundDots := 0
+	var secondDot int
+	for i, ch := range jwt {
+		if ch == '.' {
+			foundDots++
+			if foundDots == 2 {
+				secondDot = i
+				break
+			}
+		}
+	}
+	if foundDots != 2 {
+		return nil, nil, fmt.Errorf("jwt didn't have 2 dots")
+	}
+
+	signingPayload, sig := jwt[:secondDot], jwt[secondDot+1:]
+
+	signature, err = Base64DecodeForJWT(sig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return signingPayload, signature, nil
+}


### PR DESCRIPTION
Closes #8 

Adds a `gq` package for GQ signature support. The package stands alone at the moment, it isn't actually used by any of the other code yet.

Currently, an OpenPubkey token contains the original signature from the OIDC provider. This arguably means that it isn't safe to share the OpenPubkey token, as the token could be used to impersonate the subject to a service that doesn't check the audience claim, or to trick an OpenPubkey client to issue a token for the subject.

We can create a GQ signature to prove that we have the original OIDC provider's signature. This can be verified using the original OIDC signing payload (`header || '.' || payload`) and the OIDC provider's public key. This works because GQ signature private keys are equivalent to RSA signatures.

The algorithms described here are from GQ1 in [ISO/IEC 14888-2:2008](https://www.iso.org/standard/44227.html).

## Notation

If $n$ is a number, $|n|$ is the number of bits required to store $n$.

## Signing flow

### Input

$M$: message to sign
$v$, $n$: public exponent and modulus from OIDC provider's public key
$x$: RSA signature from OIDC ID token
$t$: signature length parameter (number of (challenge, response) pairs below), to achieve $\lambda$-bit soundness this should be set to $\lambda / (|v|-1)$.

### Algorithm

0. Calculate $Q \gets x^{-1} \mod n$
1. Select $t$ numbers, $r_1, r_2, \dots, r_t$, each consisting of $|n|$ random bits
2. For $i$ from 1 to $t$, calculate $W_i \gets r_i^v \mod n$, combine to form $W$
3. Hash $W||M$ and take the first $t \times (|v|-1)$ bits as $R$, split $R$ into $t$ parts
4. For $i$ from 1 to $t$, calculate $S_i \gets r_i \times Q^{R_i} \mod n$, combine to form $S$
5. Signature is $(R, S)$

## Verification flow

### Input

$M$: signed message
$R, S$: signature
$v$, $n$: public exponent and modulus from OIDC provider's public key
$Id$: Signing payload for RSA signature $x$ given as input to signing flow (OIDC ID token header/payload)
$t$: signature length parameter, must match $t$ for signing flow

### Algorithm

0. Reject if $|R| \neq t \times (|v|-1)$ or $|S| \neq t \times |n|$
1. Calculate $G \gets \text{format}(Id)$ (for RSA-signed JWT this should be PKCS#1 v1.5)
2. Split $R$ and $S$ into $t$ parts. For $i$ from 1 to $t$, calculate $W^\*_i \gets S_i^v \times G^{R_i} \mod n$, combine to form $W^\*$. Reject if any $S_i = 0$ or $S_i \geq n$.
3. Hash $W^\*||M$ and take the first $t(|v|-1)$ bits as $R^\*$, split $R^\*$ into $t$ parts
4. Accept if $R$ and $R^\*$ are identical, otherwise reject

## Potential issues

Go's math/big package says:

> Note that methods may leak the Int's value through timing side-channels. Because of this and because of the scope and complexity of the implementation, Int is not well-suited to implement cryptographic operations. The standard library avoids exposing non-trivial Int methods to attacker-controlled inputs and the determination of whether a bug in math/big is considered a security vulnerability might depend on the impact on the standard library. 

I'm not sure if this is a problem at the moment.

We currently just pass the OIDC payload as the message to be signed. This could be something more useful. I think it's fine to basically sign the public key?