### PR TITLE
Add GQ sign/verify support on PK tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ This repo contains the current reference implementation of OpenPubkey. The refer
   - [ ] MFA Cosigner example
   - [ ] Webauthn support
 
-<!-- # How to use this library
+# How to use this library
 
-...
+To interact with OpenPubkey as a signer use the OpkClient struct.
 
-# How it works
+
+<!-- # How it works
 
 ... -->
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ This repo contains the current reference implementation of OpenPubkey. The refer
 
 - [x] Signing example
 - [ ] Common OpenPubkey client struct constructor that supports:
-  - [ ] Github OpenID Provider (OP) with CIC in `aud` claim 
+  - [ ] Github OpenID Provider (OP) with CIC in `aud` claim
   - [ ] Azure OpenID Provider (OP)
   - [x] Google OpenID Provider (OP)
-- [ ] GQ Signature Support
-  - [ ] GQ signer and verifier
-  - [ ] GQ JWS Support
+- [x] GQ Signature Support
+  - [x] GQ signer and verifier
+  - [x] GQ JWS Support
 - [ ] MFA Cosigner
   - [ ] MFA Cosigner example
   - [ ] Webauthn support

--- a/examples/google/config.go
+++ b/examples/google/config.go
@@ -3,9 +3,11 @@ package main
 import "fmt"
 
 var (
-	key          = []byte("NotASecureKey123")
-	clientID     = "YOUR GOOGLE CLIENT ID"
-	clientSecret = "YOUR GOOGLE CLIENT SECRET" // Google requires a ClientSecret even if this a public OIDC App
+	key              = []byte("NotASecureKey123")
+	clientID         = "184968138938-g1fddl5tglo7mnlbdak8hbsqhhf79f32.apps.googleusercontent.com"
+	requiredAudience = "184968138938-g1fddl5tglo7mnlbdak8hbsqhhf79f32.apps.googleusercontent.com"
+	// The clientSecret was intentionally checked in for the purposes of this example,. It holds no power. Do not report as a security issue
+	clientSecret = "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" // Google requires a ClientSecret even if this a public OIDC App
 	issuer       = "https://accounts.google.com"
 	scopes       = []string{"openid profile email"}
 	redirURIPort = "3000"

--- a/examples/google/example.go
+++ b/examples/google/example.go
@@ -30,14 +30,16 @@ func GoogleSign() {
 	}
 
 	client := &parties.OpkClient{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		Issuer:       issuer,
-		Scopes:       scopes,
-		RedirURIPort: redirURIPort,
-		CallbackPath: callbackPath,
-		RedirectURI:  redirectURI,
-		Signer:       signer,
+		Signer: signer,
+		Op: &parties.GoogleOp{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			Issuer:       issuer,
+			Scopes:       scopes,
+			RedirURIPort: redirURIPort,
+			CallbackPath: callbackPath,
+			RedirectURI:  redirectURI,
+		},
 	}
 
 	msg, err := os.ReadFile("hunter.txt")
@@ -87,14 +89,16 @@ func GoogleCert() {
 	}
 
 	client := &parties.OpkClient{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		Issuer:       issuer,
-		Scopes:       scopes,
-		RedirURIPort: redirURIPort,
-		CallbackPath: callbackPath,
-		RedirectURI:  redirectURI,
-		Signer:       signer,
+		Op: &parties.GoogleOp{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			Issuer:       issuer,
+			Scopes:       scopes,
+			RedirURIPort: redirURIPort,
+			CallbackPath: callbackPath,
+			RedirectURI:  redirectURI,
+		},
+		Signer: signer,
 	}
 
 	certBytes, err := client.RequestCert()
@@ -171,24 +175,22 @@ func main() {
 
 	if command == "login" {
 		opkClientAlg := "ES256"
+		gq := false
 
 		client := &parties.OpkClient{
-			ClientID:     clientID,
-			ClientSecret: clientSecret,
-			Signer:       pktoken.NewSigner(fpClientCfg, opkClientAlg),
-			Issuer:       issuer,
-			Scopes:       scopes,
-			RedirURIPort: redirURIPort,
-			CallbackPath: callbackPath,
-			RedirectURI:  redirectURI,
-			MfaURI:       "http://localhost:3001/mfa-request",
+			Op: &parties.GoogleOp{
+				ClientID:     clientID,
+				ClientSecret: clientSecret,
+				Issuer:       issuer,
+				Scopes:       scopes,
+				RedirURIPort: redirURIPort,
+				CallbackPath: callbackPath,
+				RedirectURI:  redirectURI,
+			},
+			Signer: pktoken.NewSigner(fpClientCfg, opkClientAlg, gq),
 		}
 
-		err := client.OidcAuth()
-		if err != nil {
-			fmt.Printf("Error parsing PK Token: %s\n", err.Error())
-			return
-		}
+		client.OidcAuth()
 	}
 
 	if command == "sign" {

--- a/examples/google/example.go
+++ b/examples/google/example.go
@@ -175,7 +175,7 @@ func main() {
 
 	if command == "login" {
 		opkClientAlg := "ES256"
-		gq := false
+		gq := true
 
 		client := &parties.OpkClient{
 			Op: &parties.GoogleOp{

--- a/gq/gq_test.go
+++ b/gq/gq_test.go
@@ -24,7 +24,7 @@ func TestProveVerify(t *testing.T) {
 
 	idToken := createOIDCToken(oidcPrivKey, "test")
 
-	identity, _, err := util.SplitDecodeJWTSignature(idToken)
+	identity, _, err := util.SplitJWT(idToken)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gq/sign.go
+++ b/gq/sign.go
@@ -57,7 +57,7 @@ func (sv *signerVerifier) Sign(private []byte, message []byte) []byte {
 }
 
 func (sv *signerVerifier) SignJWTIdentity(jwt []byte) ([]byte, error) {
-	signingPayload, signature, err := util.SplitDecodeJWTSignature(jwt)
+	signingPayload, signature, err := util.SplitDecodeJWT(jwt)
 	if err != nil {
 		return nil, err
 	}

--- a/gq/verify.go
+++ b/gq/verify.go
@@ -1,9 +1,9 @@
 package gq
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
-	"slices"
 
 	"github.com/bastionzero/openpubkey/util"
 )
@@ -65,7 +65,7 @@ func (sv *signerVerifier) Verify(proof []byte, identity []byte, message []byte) 
 	Rstar := hash(t*vBytes, Wstar, M)
 
 	// Stage 4 - accept or reject depending on whether R and R* are identical
-	return slices.Equal(R, Rstar)
+	return bytes.Equal(R, Rstar)
 }
 
 func (sv *signerVerifier) decodeProof(s []byte) (R, S []byte, err error) {

--- a/parties/githubclient.go
+++ b/parties/githubclient.go
@@ -1,0 +1,18 @@
+package parties
+
+import (
+	"crypto/ecdsa"
+)
+
+type GithubOp struct {
+}
+
+func (h *GithubOp) RequestTokens(cicHash string, cb TokenCallback) error {
+	// TODO: Add github action call here
+	return nil
+}
+
+func (h *GithubOp) VerifyPKToken(pktCom []byte, cosPk *ecdsa.PublicKey) error {
+	// TODO: Add github action call here
+	return nil
+}

--- a/parties/googleclient.go
+++ b/parties/googleclient.go
@@ -1,0 +1,166 @@
+package parties
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"runtime"
+
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/sirupsen/logrus"
+	"github.com/zitadel/oidc/v2/pkg/client/rp"
+	"github.com/zitadel/oidc/v2/pkg/oidc"
+
+	httphelper "github.com/zitadel/oidc/v2/pkg/http"
+
+	"github.com/bastionzero/openpubkey/pktoken"
+)
+
+var (
+	key = []byte("NotASecureKey123")
+)
+
+type GoogleOp struct {
+	ClientID     string
+	ClientSecret string
+	Issuer       string
+	Scopes       []string
+	RedirURIPort string
+	CallbackPath string
+	RedirectURI  string
+	server       *http.Server
+}
+
+func (g *GoogleOp) RequestTokens(cicHash string, cb TokenCallback) error {
+	cookieHandler :=
+		httphelper.NewCookieHandler(key, key, httphelper.WithUnsecure())
+	options := []rp.Option{
+		rp.WithCookieHandler(cookieHandler),
+		rp.WithVerifierOpts(
+			rp.WithIssuedAtOffset(5*time.Second), rp.WithNonce(
+				func(ctx context.Context) string { return cicHash })),
+	}
+	options = append(options, rp.WithPKCE(cookieHandler))
+
+	provider, err := rp.NewRelyingPartyOIDC(
+		g.Issuer, g.ClientID, g.ClientSecret, g.RedirectURI,
+		g.Scopes, options...)
+	if err != nil {
+		logrus.Fatalf("error creating provider %s", err.Error())
+	}
+
+	state := func() string {
+		return uuid.New().String()
+	}
+
+	http.Handle("/login", rp.AuthURLHandler(state, provider, rp.WithURLParam("nonce", cicHash)))
+
+	marshalToken := func(w http.ResponseWriter, r *http.Request, tokens *oidc.Tokens[*oidc.IDTokenClaims], state string, rp rp.RelyingParty) {
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		cb(tokens)
+
+		w.Write([]byte("You may now close this window"))
+	}
+
+	http.Handle(g.CallbackPath, rp.CodeExchangeHandler(marshalToken, provider))
+
+	lis := fmt.Sprintf("localhost:%s", g.RedirURIPort)
+	g.server = &http.Server{
+		Addr: lis,
+	}
+
+	logrus.Infof("listening on http://%s/", lis)
+	logrus.Info("press ctrl+c to stop")
+	earl := fmt.Sprintf("http://localhost:%s/login", g.RedirURIPort)
+	openUrl(earl)
+	logrus.Fatal(g.server.ListenAndServe())
+
+	return nil
+}
+
+func (g *GoogleOp) VerifyPKToken(pktCom []byte, cosPk *ecdsa.PublicKey) error {
+
+	pkt, err := pktoken.FromCompact(pktCom)
+	if err != nil {
+		logrus.Fatalf("Error parsing PK Token: %s", err.Error())
+		return err
+	}
+
+	nonce, err := pkt.GetNonce()
+	if err != nil {
+		logrus.Fatalf("Error parsing PK Token: %s", err.Error())
+		return err
+	}
+
+	options := []rp.Option{
+		rp.WithVerifierOpts(rp.WithIssuedAtOffset(5*time.Second), rp.WithNonce(func(ctx context.Context) string { return string(nonce) })),
+	}
+
+	googleRP, err := rp.NewRelyingPartyOIDC(
+		g.Issuer, g.ClientID, g.ClientSecret, g.RedirectURI, g.Scopes,
+		options...)
+
+	if err != nil {
+		logrus.Fatalf("Failed to create RP to verify token: %s", err.Error())
+		return err
+	}
+
+	idt := string(pkt.OpJWSCompact())
+	_, err = rp.VerifyIDToken[*oidc.IDTokenClaims](context.TODO(), idt, googleRP.IDTokenVerifier())
+	if err != nil {
+		logrus.Fatalf("Error verifying OP signature on PK Token (ID Token invalid): %s", err.Error())
+		return err
+	}
+
+	err = pkt.VerifyCicSig()
+	if err != nil {
+		logrus.Fatalf("Error verifying CIC signature on PK Token: %s", err.Error())
+		return err
+	}
+
+	// Skip Cosigner signature verification if no cosigner pubkey is supplied
+	if cosPk != nil {
+		cosPkJwk, err := jwk.FromRaw(cosPk)
+		if err != nil {
+			logrus.Fatalf("Error verifying CIC signature on PK Token: %s", err.Error())
+			return err
+		}
+
+		err = pkt.VerifyCosSig(cosPkJwk, jwa.KeyAlgorithmFrom("ES256"))
+		if err != nil {
+			logrus.Fatalf("Error verify cosigner signature on PK Token: %s", err.Error())
+			return err
+		}
+	}
+
+	fmt.Println("All tests have passed PK Token is valid")
+	return nil
+}
+
+// https://stackoverflow.com/questions/39320371/how-start-web-server-to-open-page-in-browser-in-golang
+// open opens the specified URL in the default browser of the user.
+func openUrl(url string) error {
+	var cmd string
+	var args []string
+
+	switch runtime.GOOS {
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start"}
+	case "darwin":
+		cmd = "open"
+	default: // "linux", "freebsd", "openbsd", "netbsd"
+		cmd = "xdg-open"
+	}
+	args = append(args, url)
+	return exec.Command(cmd, args...).Start()
+}

--- a/parties/opkclient.go
+++ b/parties/opkclient.go
@@ -1,44 +1,58 @@
 package parties
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"fmt"
 	"io"
 	"net/http"
-	"os/exec"
-	"runtime"
 
-	"time"
-
-	"github.com/google/uuid"
-	"github.com/lestrrat-go/jwx/v2/jwa"
-	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/sirupsen/logrus"
-	"github.com/zitadel/oidc/v2/pkg/client/rp"
 	"github.com/zitadel/oidc/v2/pkg/oidc"
-
-	httphelper "github.com/zitadel/oidc/v2/pkg/http"
 
 	"github.com/bastionzero/openpubkey/pktoken"
 )
 
-var (
-	key = []byte("NotASecureKey123")
-)
+// Interface for interacting with the MFA Cosigner (MFACos)
+type MFACos interface {
+	// place holder for MFA Cosigner
+	// TODO: Add MFA Cosigner
+}
 
 type OpkClient struct {
-	PktCom       []byte
-	Signer       *pktoken.Signer
-	ClientID     string
-	ClientSecret string
-	Issuer       string
-	Scopes       []string
-	RedirURIPort string
-	CallbackPath string
-	RedirectURI  string
-	MfaURI       string
-	server       *http.Server
+	PktCom      []byte
+	Signer      *pktoken.Signer
+	Op          OpenIdProvider
+	MFACosigner MFACos
+}
+
+func (o *OpkClient) OidcAuth() {
+	nonce := o.Signer.GetNonce()
+	receiveIDTHandler := func(tokens *oidc.Tokens[*oidc.IDTokenClaims]) {
+		idt := []byte(tokens.IDToken)
+		pkt, err := o.Signer.CreatePkToken(idt)
+
+		if err != nil {
+			logrus.Fatalf("Error creating PK Token: %s", err.Error())
+			return
+		}
+		pktCom := pkt.ToCompact()
+		fmt.Printf("PKT=%s", pktCom)
+		o.Op.VerifyPKToken(pktCom, nil)
+		err = o.Signer.WriteToFile(pktCom)
+		if err != nil {
+			logrus.Fatalf("Error creating PK Token: %s", err.Error())
+			return
+		}
+	}
+	o.Op.RequestTokens(nonce, receiveIDTHandler)
+}
+
+type TokenCallback func(tokens *oidc.Tokens[*oidc.IDTokenClaims])
+
+// Interface for interacting with the OP (OpenID Provider)
+type OpenIdProvider interface {
+	RequestTokens(cicHash string, cb TokenCallback) error
+	VerifyPKToken(pktCom []byte, cosPk *ecdsa.PublicKey) error
 }
 
 func (o *OpkClient) RequestCert() ([]byte, error) {
@@ -49,157 +63,6 @@ func (o *OpkClient) RequestCert() ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-
 	certBytes, err := io.ReadAll(resp.Body)
-
 	return certBytes, nil
-}
-
-func (o *OpkClient) OidcAuth() error {
-	nonce := o.Signer.GetNonce()
-
-	receiveIDTHandler := func(tokens *oidc.Tokens[*oidc.IDTokenClaims]) {
-
-	}
-
-	o.PerformGoogleAuthFlow(nonce, receiveIDTHandler)
-
-	return nil
-}
-
-type ReceiveIDTHandler func(tokens *oidc.Tokens[*oidc.IDTokenClaims])
-
-func (o *OpkClient) PerformGoogleAuthFlow(nonce string, receiveIDTHandler ReceiveIDTHandler) {
-
-	cookieHandler := httphelper.NewCookieHandler(key, key, httphelper.WithUnsecure())
-	options := []rp.Option{
-		rp.WithCookieHandler(cookieHandler),
-		rp.WithVerifierOpts(rp.WithIssuedAtOffset(5*time.Second), rp.WithNonce(func(ctx context.Context) string { return nonce })),
-	}
-	options = append(options, rp.WithPKCE(cookieHandler))
-
-	provider, err := rp.NewRelyingPartyOIDC(o.Issuer, o.ClientID, o.ClientSecret, o.RedirectURI, o.Scopes, options...)
-	if err != nil {
-		logrus.Fatalf("error creating provider %s", err.Error())
-	}
-
-	state := func() string {
-		return uuid.New().String()
-	}
-
-	http.Handle("/login", rp.AuthURLHandler(state, provider, rp.WithURLParam("nonce", nonce)))
-
-	marshalToken := func(w http.ResponseWriter, r *http.Request, tokens *oidc.Tokens[*oidc.IDTokenClaims], state string, rp rp.RelyingParty) {
-		// data, err := json.Marshal(tokens)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		// w.Write(data)
-
-		idt := []byte(tokens.IDToken)
-		pkt, err := o.Signer.CreatePkToken(idt)
-
-		if err != nil {
-			logrus.Fatalf("Error creating PK Token: %s", err.Error())
-			return
-		}
-
-		pktCom := pkt.ToCompact()
-		fmt.Printf("PKT=%s", pktCom)
-
-		err = o.Signer.WriteToFile(pktCom)
-		if err != nil {
-			logrus.Fatalf("Error creating PK Token: %s", err.Error())
-			return
-		}
-
-		w.Write([]byte("You may now close this window"))
-	}
-
-	http.Handle(o.CallbackPath, rp.CodeExchangeHandler(marshalToken, provider))
-
-	lis := fmt.Sprintf("localhost:%s", o.RedirURIPort)
-	o.server = &http.Server{
-		Addr: lis,
-	}
-	// defer o.server.Close()
-
-	logrus.Infof("listening on http://%s/", lis)
-	logrus.Info("press ctrl+c to stop")
-	earl := fmt.Sprintf("http://localhost:%s/login", o.RedirURIPort)
-	openUrl(earl)
-	logrus.Fatal(o.server.ListenAndServe())
-
-}
-
-func (o *OpkClient) VerifyPKToken(pktCom []byte, cosPk *ecdsa.PublicKey) error {
-
-	pkt, err := pktoken.FromCompact(pktCom)
-	if err != nil {
-		logrus.Fatalf("Error parsing PK Token: %s", err.Error())
-		return err
-	}
-
-	nonce, err := pkt.GetNonce()
-	if err != nil {
-		logrus.Fatalf("Error parsing PK Token: %s", err.Error())
-		return err
-	}
-
-	options := []rp.Option{
-		rp.WithVerifierOpts(rp.WithIssuedAtOffset(5*time.Second), rp.WithNonce(func(ctx context.Context) string { return string(nonce) })),
-	}
-
-	googleRP, err := rp.NewRelyingPartyOIDC(o.Issuer, o.ClientID, o.ClientSecret, o.RedirectURI, o.Scopes, options...)
-	if err != nil {
-		logrus.Fatalf("Failed to create RP to verify token: %s", err.Error())
-		return err
-	}
-
-	idt := string(pkt.OpJWSCompact())
-	_, err = rp.VerifyIDToken[*oidc.IDTokenClaims](context.TODO(), idt, googleRP.IDTokenVerifier())
-	if err != nil {
-		logrus.Fatalf("Error verifying OP signature on PK Token (ID Token invalid): %s", err.Error())
-		return err
-	}
-
-	err = pkt.VerifyCicSig()
-	if err != nil {
-		logrus.Fatalf("Error verifying CIC signature on PK Token: %s", err.Error())
-		return err
-	}
-	cosPkJwk, err := jwk.FromRaw(cosPk)
-	if err != nil {
-		logrus.Fatalf("Error verifying CIC signature on PK Token: %s", err.Error())
-		return err
-	}
-
-	err = pkt.VerifyCosSig(cosPkJwk, jwa.KeyAlgorithmFrom("ES256"))
-	if err != nil {
-		logrus.Fatalf("Error verify cosigner signature on PK Token: %s", err.Error())
-		return err
-	}
-
-	fmt.Println("All tests have passed PK Token is valid")
-	return nil
-}
-
-// https://stackoverflow.com/questions/39320371/how-start-web-server-to-open-page-in-browser-in-golang
-// open opens the specified URL in the default browser of the user.
-func openUrl(url string) error {
-	var cmd string
-	var args []string
-
-	switch runtime.GOOS {
-	case "windows":
-		cmd = "cmd"
-		args = []string{"/c", "start"}
-	case "darwin":
-		cmd = "open"
-	default: // "linux", "freebsd", "openbsd", "netbsd"
-		cmd = "xdg-open"
-	}
-	args = append(args, url)
-	return exec.Command(cmd, args...).Start()
 }

--- a/pktoken/pktoken.go
+++ b/pktoken/pktoken.go
@@ -14,10 +14,22 @@ import (
 	"github.com/bastionzero/openpubkey/util"
 )
 
+type JWS struct {
+	Payload    string        `json:"payload"`
+	Signatures []JWSignature `json:"signatures"`
+}
+
+type JWSignature struct {
+	Protected string         `json:"protected"`
+	Public    map[string]any `json:"header"`
+	Signature string         `json:"signature"`
+}
+
 type PKToken struct {
 	Payload []byte
 	OpPH    []byte
 	OpSig   []byte
+	OpSigGQ bool
 	CicPH   []byte
 	CicSig  []byte
 	CosPH   []byte
@@ -49,6 +61,119 @@ func FromCompact(pktCom []byte) (*PKToken, error) {
 	} else {
 		return nil, fmt.Errorf("A valid PK Token should have exactly two or three (protected header, signature pairs), but has %d signatures", len(splitCom))
 	}
+}
+
+func (p *PKToken) ToCompact() []byte {
+	if p.Payload == nil {
+		panic(fmt.Errorf("Payload can not be nil"))
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString(string(p.Payload))
+	buf.WriteByte(':')
+	buf.WriteString(string(p.OpPH))
+	buf.WriteByte(':')
+	buf.WriteString(string(p.OpSig))
+	buf.WriteByte(':')
+	buf.WriteString(string(p.CicPH))
+	buf.WriteByte(':')
+	buf.WriteString(string(p.CicSig))
+
+	if p.CosPH != nil {
+		buf.WriteByte(':')
+		buf.WriteString(string(p.CosPH))
+		buf.WriteByte(':')
+		buf.WriteString(string(p.CosSig))
+	}
+
+	pktCom := buf.Bytes()
+	return pktCom
+}
+
+func FromJWS(jws *JWS) *PKToken {
+	var cic, op, cos JWSignature
+
+	gq := false
+	for _, sig := range jws.Signatures {
+		switch sig.Public["sig_type"] {
+		case "oidc":
+			op = sig
+		case "oidc_gq":
+			op = sig
+			gq = true
+		case "cic":
+			cic = sig
+		}
+	}
+
+	return &PKToken{
+		Payload: []byte(jws.Payload),
+		OpPH:    []byte(op.Protected),
+		OpSig:   []byte(op.Signature),
+		OpSigGQ: gq,
+		CicPH:   []byte(cic.Protected),
+		CicSig:  []byte(cic.Signature),
+		CosPH:   []byte(cos.Protected),
+		CosSig:  []byte(cos.Signature),
+	}
+}
+
+func (p *PKToken) ToJWS() *JWS {
+	var opSignType string
+	if p.OpSigGQ {
+		opSignType = "oidc_gq"
+	} else {
+		opSignType = "oidc"
+	}
+
+	opHeaders := map[string]any{
+		"sig_type": opSignType,
+	}
+
+	signatures := []JWSignature{
+		{
+			Public:    map[string]any{"sig_type": "cic"},
+			Protected: string(p.CicPH),
+			Signature: string(p.CicSig),
+		},
+		{
+			Public:    opHeaders,
+			Protected: string(p.OpPH),
+			Signature: string(p.OpSig),
+		},
+	}
+
+	if p.CosPH != nil {
+		signatures = append(signatures, JWSignature{
+			Public:    map[string]any{"sig_type": "cos"},
+			Protected: string(p.CosPH),
+			Signature: string(p.CosSig),
+		})
+	}
+
+	return &JWS{
+		Payload:    string(p.Payload),
+		Signatures: signatures,
+	}
+}
+
+func FromJSON(in []byte) (*PKToken, error) {
+	jws := new(JWS)
+	err := json.Unmarshal(in, jws)
+	if err != nil {
+		return nil, err
+	}
+
+	return FromJWS(jws), nil
+}
+
+func (p *PKToken) ToJSON() ([]byte, error) {
+	jws := p.ToJWS()
+	jwsJSON, err := json.Marshal(jws)
+	if err != nil {
+		return nil, err
+	}
+	return jwsJSON, nil
 }
 
 func (p *PKToken) OpJWSCompact() []byte {
@@ -97,33 +222,6 @@ func (p *PKToken) CosJWSCompact() []byte {
 
 	jwsCom := buf.Bytes()
 	return jwsCom
-}
-
-func (p *PKToken) ToCompact() []byte {
-	if p.Payload == nil {
-		panic(fmt.Errorf("Payload can not be nil"))
-	}
-
-	var buf bytes.Buffer
-	buf.WriteString(string(p.Payload))
-	buf.WriteByte(':')
-	buf.WriteString(string(p.OpPH))
-	buf.WriteByte(':')
-	buf.WriteString(string(p.OpSig))
-	buf.WriteByte(':')
-	buf.WriteString(string(p.CicPH))
-	buf.WriteByte(':')
-	buf.WriteString(string(p.CicSig))
-
-	if p.CosPH != nil {
-		buf.WriteByte(':')
-		buf.WriteString(string(p.CosPH))
-		buf.WriteByte(':')
-		buf.WriteString(string(p.CosSig))
-	}
-
-	pktCom := buf.Bytes()
-	return pktCom
 }
 
 func (p *PKToken) GetNonce() ([]byte, error) {

--- a/pktoken/signer.go
+++ b/pktoken/signer.go
@@ -20,17 +20,19 @@ import (
 	"github.com/bastionzero/openpubkey/util"
 )
 
-// variable names with a postfix of Com denotes compact representation
+// Variable names with a postfix of "com" denotes that value is stored as a compact JWT representation (See RFC7519)
+// https://datatracker.ietf.org/doc/html/rfc7519
 
 type Signer struct {
 	Pksk    *ecdsa.PrivateKey
 	alg     string
 	rz      string
 	cfgPath string
+	GqSig   bool
 	PktCom  []byte
 }
 
-func NewSigner(cfgPath string, alg string) *Signer {
+func NewSigner(cfgPath string, alg string, gqSig bool) *Signer {
 	pksk, err := util.GenKeyPair(alg)
 	if err != nil {
 		panic(err)
@@ -41,6 +43,7 @@ func NewSigner(cfgPath string, alg string) *Signer {
 		Pksk:    pksk,
 		alg:     alg,
 		rz:      rz,
+		GqSig:   gqSig,
 		cfgPath: cfgPath,
 	}
 

--- a/pktoken/signer.go
+++ b/pktoken/signer.go
@@ -138,8 +138,11 @@ func (s *Signer) CreatePkToken(idtCom []byte) (*PKToken, error) {
 	}
 
 	cicPH, cicPayload, cicSig, err := jws.SplitCompact(cicsigb64)
+	if err != nil {
+		return nil, err
+	}
 	if !bytes.Equal(opPayload, cicPayload) {
-		return nil, fmt.Errorf("Both signatures must share the same payload, opPayload=%s,  cicPayload=%s", opPayload, cicPayload)
+		return nil, fmt.Errorf("both signatures must share the same payload, opPayload=%s,  cicPayload=%s", opPayload, cicPayload)
 	}
 	payload := opPayload
 

--- a/pktoken/signer_test.go
+++ b/pktoken/signer_test.go
@@ -16,8 +16,9 @@ var (
 func TestSigner(t *testing.T) {
 
 	alg := "ES256"
+	gq := false
 
-	signer := NewSigner(signerConfigPath, alg)
+	signer := NewSigner(signerConfigPath, alg, gq)
 
 	sigma, err := signer.Sign([]byte("abcdefgh"))
 

--- a/pktoken/signer_test.go
+++ b/pktoken/signer_test.go
@@ -14,32 +14,50 @@ var (
 )
 
 func TestSigner(t *testing.T) {
-
 	alg := "ES256"
-	gq := false
 
-	signer := NewSigner(signerConfigPath, alg, gq)
-
-	sigma, err := signer.Sign([]byte("abcdefgh"))
-
-	err = signer.Verify(sigma)
-	if err != nil {
-		t.Error(err)
+	testCases := []struct {
+		name string
+		gq   bool
+	}{
+		{name: "without GQ", gq: false},
+		{name: "with GQ", gq: true},
 	}
 
-	msg, err := jws.Parse(sigma)
-	if err != nil {
-		t.Error(err)
-	}
-	if msg == nil {
-		t.Error("Message should not be nil, but is nil")
-	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			signer := NewSigner(signerConfigPath, alg, tc.gq)
 
-	sigma2, err := signer.Sign([]byte("hgfedcba"))
+			// TODO: test signer.CreatePkToken
 
-	err = signer.Verify(sigma2)
-	if err != nil {
-		t.Error(err)
+			sigma, err := signer.Sign([]byte("abcdefgh"))
+			if err != nil {
+				t.Error(err)
+			}
+
+			err = signer.Verify(sigma)
+			if err != nil {
+				t.Error(err)
+			}
+
+			msg, err := jws.Parse(sigma)
+			if err != nil {
+				t.Error(err)
+			}
+			if msg == nil {
+				t.Error("Message should not be nil, but is nil")
+			}
+
+			sigma2, err := signer.Sign([]byte("hgfedcba"))
+			if err != nil {
+				t.Error(err)
+			}
+
+			err = signer.Verify(sigma2)
+			if err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }
 

--- a/util/jwt.go
+++ b/util/jwt.go
@@ -2,7 +2,9 @@ package util
 
 import "fmt"
 
-func SplitDecodeJWTSignature(jwt []byte) (signingPayload []byte, signature []byte, err error) {
+// SplitJWT splits a JWT token into the signing payload and the signature parts.
+// The signing payload is `header || '.' || payload`.
+func SplitJWT(jwt []byte) (signingPayload []byte, signature []byte, err error) {
 	foundDots := 0
 	var secondDot int
 	for i, ch := range jwt {
@@ -18,7 +20,18 @@ func SplitDecodeJWTSignature(jwt []byte) (signingPayload []byte, signature []byt
 		return nil, nil, fmt.Errorf("jwt didn't have 2 dots")
 	}
 
-	signingPayload, sig := jwt[:secondDot], jwt[secondDot+1:]
+	signingPayload, signature = jwt[:secondDot], jwt[secondDot+1:]
+
+	return signingPayload, signature, nil
+}
+
+// SplitDecodeJWT splits a JWT token into the signing payload and the signature parts,
+// and base64-decodes the signature.
+func SplitDecodeJWT(jwt []byte) (signingPayload []byte, signature []byte, err error) {
+	signingPayload, sig, err := SplitJWT(jwt)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	signature, err = Base64DecodeForJWT(sig)
 	if err != nil {


### PR DESCRIPTION
Closes #9 
Closes #10 
Closes #4

- Makes opkclient more plugable for github actions
- Use bytes.Equal instead of slices for Go 1.20
- Add GQ sign/verify support on PK tokens

Also use verbose JWS format for PK tokens. @EthanHeilman I wasn't sure if the compact JWS format with `:`s was needed so I've left the code there, if it's not needed we can remove it.

